### PR TITLE
Pass through kwargs to cursor.

### DIFF
--- a/riopg/connection.py
+++ b/riopg/connection.py
@@ -119,19 +119,19 @@ class Connection(object):
         self._sock = socket.fromfd(self._connection.fileno(), socket.AF_INET, socket.SOCK_STREAM)
         await self._wait_callback()
 
-    def _cursor(self):
+    def _cursor(self, **kwargs):
         """
         Internal implementation of acquiring a cursor.
         """
-        return self._connection.cursor()
+        return self._connection.cursor(**kwargs)
 
-    async def cursor(self) -> 'md_cursor.Cursor':
+    async def cursor(self, **kwargs) -> 'md_cursor.Cursor':
         """
         Gets a new cursor object.
 
         :return: A :class:`.cursor.Cursor` object attached to this connection.
         """
-        cur = md_cursor.Cursor(self)
+        cur = md_cursor.Cursor(self, kwargs)
         await cur.open()
         return cur
 

--- a/riopg/cursor.py
+++ b/riopg/cursor.py
@@ -27,11 +27,12 @@ class Cursor(object):
     Wraps a :class:`psycopg2.cursor` object.
     """
 
-    def __init__(self, connection: 'md_connection.Connection'):
+    def __init__(self, connection: 'md_connection.Connection', kwargs):
         """
         :param connection: The :class:`.Connection` object this cursor was created under.
         """
         self._connection = connection
+        self._kwargs = kwargs
 
         #: The underlying cursor object.
         self._cursor = None  # type: cursor
@@ -42,7 +43,7 @@ class Cursor(object):
 
         This is usually called automatically by :meth:`.Connection.open`.
         """
-        self._cursor = await self._connection._do_async(self._connection._cursor)
+        self._cursor = await self._connection._do_async(partial(self._connection._cursor, **self._kwargs))
 
     # catch-all handler
     def __getattr__(self, item):


### PR DESCRIPTION
This allows for example a custom `cursor_factory`.